### PR TITLE
Fix index error when running tests on latest spec

### DIFF
--- a/CommonMark/common.py
+++ b/CommonMark/common.py
@@ -1,3 +1,5 @@
+import re
+
 # Some of the regexps used in inline parser :<
 
 ESCAPABLE = '[!"#$%&\'()*+,./:;<=>?@[\\\\\\]^_`{|}~-]'
@@ -28,12 +30,13 @@ OPENBLOCKTAG = "<" + BLOCKTAGNAME + ATTRIBUTE + "*" + "\\s*/?>"
 CLOSEBLOCKTAG = "</" + BLOCKTAGNAME + "\\s*[>]"
 # HTML comments are more complex than something between <!-- and -->
 # http://www.w3.org/TR/html5/syntax.html#comments
-HTMLCOMMENT = "<!--(?!>|->)(?:[^-]|-(?!-))*?-->"
+HTMLCOMMENT = '<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->'
 PROCESSINGINSTRUCTION = "[<][?].*?[?][>]"
 DECLARATION = "<![A-Z]+" + "\\s+[^>]*>"
-CDATA = "<!\\[CDATA\\[([^\\]]+|\\][^\\]]|\\]\\][^>])*\\]\\]>"
+CDATA = '<!\\[CDATA\\[[\\s\\S]*?\\]\\]>'
 HTMLTAG = "(?:" + OPENTAG + "|" + CLOSETAG + "|" + HTMLCOMMENT + \
     "|" + PROCESSINGINSTRUCTION + "|" + DECLARATION + "|" + CDATA + ")"
+reHtmlTag = re.compile('^' + HTMLTAG, re.IGNORECASE)
 HTMLBLOCKOPEN = "<(?:" + BLOCKTAGNAME + \
     "[\\s/>]" + "|" + "/" + \
     BLOCKTAGNAME + "[\\s>]" + "|" + "[?!])"

--- a/CommonMark/test/test-CommonMark.py
+++ b/CommonMark/test/test-CommonMark.py
@@ -76,7 +76,7 @@ parser = CommonMark.DocParser()
 f = codecs.open("spec.txt", encoding="utf-8")
 datalist = []
 for line in f:
-        datalist.append(line)
+    datalist.append(line)
 data = "".join(datalist)
 passed = 0
 failed = 0


### PR DESCRIPTION
parseNewline threw a list index error when running CommonMark-py
against the 0.22 spec.

I've ported the changes in parseNewline from here:
https://github.com/jgm/commonmark.js/blob/master/lib/inlines.js#L738

Now commonmark-py doesn't error out when running on the new
spec, (though there are many failures) and it still works with
the old spec we're using at the moment.

I've also included more changes from commonmark.js that still work with our spec.