### PR TITLE
Cleanup / test fixes with new spec

### DIFF
--- a/CommonMark/CommonMark.py
+++ b/CommonMark/CommonMark.py
@@ -51,9 +51,9 @@ def ASTtoJSON(block):
         block elements."""
         if block.parent:
             block.parent = None
-        if not block.__dict__['isOpen'] is None:
-            block.__dict__['open'] = block.isOpen
-            del(block.isOpen)
+        if not block.__dict__['is_open'] is None:
+            block.__dict__['open'] = block.is_open
+            del(block.is_open)
         # trim empty elements...
         for attr in dir(block):
             if not callable(attr) and not attr.startswith("__") and \
@@ -89,8 +89,8 @@ def dumpAST(obj, ind=0):
         print("\t" + indChar + "Info: " + obj.info)
     if not obj.destination == "":
         print("\t" + indChar + "Destination: " + obj.destination)
-    if obj.isOpen:
-        print("\t" + indChar + "Open: " + str(obj.isOpen))
+    if obj.is_open:
+        print("\t" + indChar + "Open: " + str(obj.is_open))
     if obj.last_line_blank:
         print(
             "\t" + indChar + "Last line blank: " + str(obj.last_line_blank))

--- a/CommonMark/node.py
+++ b/CommonMark/node.py
@@ -10,21 +10,26 @@ class Node:
         self.c = c
         self.destination = destination
         self.label = label
-        self.isOpen = True
+        self.is_open = True
         self.last_line_blank = False
         self.start_line = start_line
         self.start_column = start_column
         self.end_line = start_line
         self.children = []
         self.parent = None
-        self.string_content = ""
+        self.string_content = ''
+        self.literal = None
         self.strings = []
         self.inline_content = []
         self.list_data = {}
         self.title = title
-        self.info = ""
+        self.info = ''
         self.tight = bool()
         self.attributes = {}
+        self.is_fenced = False
+        self.fence_length = 0
+        self.fence_char = None
+        self.fence_offset = None
 
     def __repr__(self):
         return "Node {t} [{start}:{end}]".format(


### PR DESCRIPTION
I've removed the ExtensionBlock code I saw Luca was working
on. This is because, when running the tests on the CommonMark
0.22 spec, I get 157 failures with the ExtensionBlock code in,
and 129 failures without. So I thought that for now we can leave
it out.