### PR TITLE
Fix duplicated lines in IndentedCode

### DIFF
--- a/CommonMark/blocks.py
+++ b/CommonMark/blocks.py
@@ -441,7 +441,7 @@ class Parser:
                 cont = cont.parent
             if container.t == "IndentedCode" or container.t == "HtmlBlock":
                 self.addLine(ln, offset)
-            if container.t == "ExtensionBlock":
+            elif container.t == "ExtensionBlock":
                 EXTmatch = re.search(r"^{:/((\\\}|[^\\}])*)} *$",
                                      ln[first_nonspace:])
                 if EXTmatch:


### PR DESCRIPTION
When parsing [CommonMark's README](https://github.com/jgm/CommonMark/blob/master/README.md) for example, each line in an indented code block is duplicated.