### PR TITLE
Fix python2 unicode error

### DIFF
--- a/CommonMark/CommonMark.py
+++ b/CommonMark/CommonMark.py
@@ -10,6 +10,7 @@
 # print(renderer.render(parser.parse('Hello *world*')))
 from __future__ import absolute_import, unicode_literals
 import json
+from builtins import str
 from CommonMark.blocks import Parser
 from CommonMark.html import HtmlRenderer
 

--- a/CommonMark/html.py
+++ b/CommonMark/html.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
-
+from builtins import str
 from CommonMark.common import escape_xml
 
 

--- a/CommonMark/test/test-CommonMark.py
+++ b/CommonMark/test/test-CommonMark.py
@@ -6,6 +6,7 @@ import time
 import codecs
 import argparse
 import sys
+from builtins import str
 import CommonMark
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
     url="https://github.com/rtfd/CommonMark-py",
     keywords=["markup", "markdown", "commonmark"],
     cmdclass={'test': Test},
+    install_requires=[
+        'future',
+    ],
     setup_requires=[
         'flake8',
     ],


### PR DESCRIPTION
Because we're converting to strings with `str()`, it's possible
to get errors like this:

> 'ascii' codec can't encode character u'\u2022' in position 47: ordinal
> not in range(128)

Using python-future, we can convert to unicode-compatible strings in
both python 2 and 3.

http://python-future.org/compatible_idioms.html#unicode

We should really have tests for stuff like this.. I will look into
adding that.