### PR TITLE
run_spec_tests pass on python26 with these changes.

### DIFF
--- a/CommonMark/__init__.py
+++ b/CommonMark/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
-__all__ = ["HtmlRenderer", "Parser", "dumpAST", "ASTtoJSON", "commonmark"]
 from CommonMark.CommonMark import HtmlRenderer
 from CommonMark.CommonMark import Parser
 from CommonMark.CommonMark import dumpAST
 from CommonMark.CommonMark import ASTtoJSON
 from CommonMark.CommonMark import commonmark
+__all__ = ["HtmlRenderer", "Parser", "dumpAST", "ASTtoJSON", "commonmark"]

--- a/CommonMark/common.py
+++ b/CommonMark/common.py
@@ -68,7 +68,7 @@ def unescape_string(s):
 
 def normalize_uri(uri):
     try:
-        return quote(uri, safe='/@:+?=&()%#*')
+        return quote(uri, safe=str('/@:+?=&()%#*'))
     except KeyError:
         # Python 2 throws a KeyError sometimes
         try:

--- a/CommonMark/html.py
+++ b/CommonMark/html.py
@@ -16,7 +16,7 @@ def tag(name, attrs=[], selfclosing=False):
     """Helper function to produce an HTML tag."""
     result = '<' + name
     for attr in attrs:
-        result += ' {}="{}"'.format(attr[0], attr[1])
+        result += ' {0}="{1}"'.format(attr[0], attr[1])
     if selfclosing:
         result += ' /'
 
@@ -112,7 +112,7 @@ class HtmlRenderer:
                             self.out('<img src="" alt="')
                         else:
                             self.out(
-                                '<img src="{}" alt="'.format(
+                                '<img src="{0}" alt="'.format(
                                     escape_xml(node.destination, True)))
                     self.disable_tags += 1
                 else:
@@ -211,7 +211,7 @@ class HtmlRenderer:
                 self.out(tag('hr', attrs, True))
                 self.cr()
             else:
-                raise ValueError('Unknown node type {}'.format(node.t))
+                raise ValueError('Unknown node type {0}'.format(node.t))
             event = walker.nxt()
         return self.buf
 

--- a/CommonMark/tests/run_spec_tests.py
+++ b/CommonMark/tests/run_spec_tests.py
@@ -98,7 +98,7 @@ def showSpaces(t):
 
 t = re.sub("\r\n", "\n", data)
 
-tests = re.sub("^<!-- END TESTS -->(.|[\n])*", '', t, flags=re.M)
+tests = re.sub(re.compile("^<!-- END TESTS -->(.|[\n])*",flags=re.M), '', t)
 testMatch = re.findall(
     re.compile(
         "^\.\n([\s\S]*?)^\.\n([\s\S]*?)^\.$|^#{1,6} *(.*)$",

--- a/CommonMark/tests/run_spec_tests.py
+++ b/CommonMark/tests/run_spec_tests.py
@@ -98,7 +98,7 @@ def showSpaces(t):
 
 t = re.sub("\r\n", "\n", data)
 
-tests = re.sub(re.compile("^<!-- END TESTS -->(.|[\n])*",flags=re.M), '', t)
+tests = re.sub(re.compile("^<!-- END TESTS -->(.|[\n])*", flags=re.M), '', t)
 testMatch = re.findall(
     re.compile(
         "^\.\n([\s\S]*?)^\.\n([\s\S]*?)^\.$|^#{1,6} *(.*)$",


### PR DESCRIPTION
I don't know whether you're interested in supporting python26, or whether these changes cause other issues. On RHEL and Centos 6 systems you're largely stuck with python26.


- Numbered substitutions in string formats.
- re.sub doesn't have flags keyword
- Pass a str to urllib.quote `safe`.

There's a UnicodeWarning, but run_spec_tests.py passes and spec.txt can be parsed.

    urllib.py:1268: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
      return ''.join(map(quoter, s))

The UnicodeWarning is also present in python 2.7.3 against master, so doesn't appear to be the result of these changes.