### PR TITLE
Add 2.6 to the Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"


### PR DESCRIPTION
We've had a few requests and PR's for 2.6 support.
There isn't a real reason we can't support it,
so let's add it to Travis so we don't break it.