### PR TITLE
Use new-style objects in python 2

### DIFF
--- a/CommonMark/blocks.py
+++ b/CommonMark/blocks.py
@@ -146,7 +146,7 @@ def lists_match(list_data, item_data):
         list_data.get('bullet_char') == item_data.get('bullet_char')
 
 
-class Block:
+class Block(object):
     accepts_lines = None
 
     @staticmethod
@@ -398,7 +398,7 @@ class Paragraph(Block):
         return False
 
 
-class BlockStarts:
+class BlockStarts(object):
     """Block start functions.
 
     Return values:
@@ -556,7 +556,7 @@ class BlockStarts:
         return 0
 
 
-class Parser:
+class Parser(object):
     def __init__(self, options={}):
         self.doc = Node('Document', [[1, 1], [0, 0]])
         self.block_starts = BlockStarts()

--- a/CommonMark/html.py
+++ b/CommonMark/html.py
@@ -29,7 +29,7 @@ def potentially_unsafe(url):
         re.search(reSafeDataProtocol, url)
 
 
-class HtmlRenderer:
+class HtmlRenderer(object):
 
     def __init__(self, options={}):
         # by default, soft breaks are rendered as newlines in HTML.

--- a/CommonMark/inlines.py
+++ b/CommonMark/inlines.py
@@ -101,7 +101,7 @@ def smart_dashes(chars):
     return ('\u2014' * em_count) + ('\u2013' * en_count)
 
 
-class InlineParser:
+class InlineParser(object):
     """INLINE PARSER
 
     These are methods of an InlineParser class, defined below.

--- a/CommonMark/node.py
+++ b/CommonMark/node.py
@@ -13,7 +13,7 @@ def is_container(node):
     return (re.match(reContainer, node.t) is not None)
 
 
-class NodeWalker:
+class NodeWalker(object):
 
     def __init__(self, root):
         self.current = root
@@ -55,7 +55,7 @@ class NodeWalker:
         self.entering = (entering is True)
 
 
-class Node:
+class Node(object):
     def __init__(self, node_type, sourcepos):
         self.t = node_type
         self.parent = None

--- a/CommonMark/tests/run_spec_tests.py
+++ b/CommonMark/tests/run_spec_tests.py
@@ -10,7 +10,7 @@ from builtins import str
 import CommonMark
 
 
-class colors:
+class colors(object):
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'


### PR DESCRIPTION
while `object` is implied as a base class in python 3, without it in python 2, it reverts to old-style classes