### PR TITLE
Make NodeWalker iterable

### DIFF
--- a/CommonMark/node.py
+++ b/CommonMark/node.py
@@ -20,12 +20,12 @@ class NodeWalker(object):
         self.root = root
         self.entering = True
 
-    def nxt(self):
+    def __next__(self):
         cur = self.current
         entering = self.entering
 
         if cur is None:
-            return None
+            raise StopIteration
 
         container = is_container(cur)
 
@@ -45,10 +45,21 @@ class NodeWalker(object):
             self.current = cur.nxt
             self.entering = True
 
-        return {
-            'entering': entering,
-            'node': cur,
-        }
+        return cur, entering
+
+    def __iter__(self):
+        return self
+
+    def nxt(self):
+        """ for backwards compatibility """
+        try:
+            cur, entering = next(self)
+            return {
+                'entering': entering,
+                'node': cur,
+            }
+        except StopIteration:
+            return None
 
     def resume_at(self, node, entering):
         self.current = node

--- a/CommonMark/node.py
+++ b/CommonMark/node.py
@@ -47,6 +47,8 @@ class NodeWalker(object):
 
         return cur, entering
 
+    next = __next__
+
     def __iter__(self):
         return self
 

--- a/CommonMark/tests/unit_tests.py
+++ b/CommonMark/tests/unit_tests.py
@@ -42,6 +42,11 @@ class TestNodeWalker(unittest.TestCase):
         node = Node('Document', [[1, 1], [0, 0]])
         NodeWalker(node)
 
+    def test_node_walker_iter(self):
+        node = Node('Document', [[1, 1], [0, 0]])
+        for subnode, entered in node.walker():
+            pass
+
 
 class TestParser(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Makes it slightly easier to iterate over nodes - before, you had to do `iter(ast.walker().nxt, None)`