### PR TITLE
Fix ast dump

### DIFF
--- a/CommonMark/CommonMark.py
+++ b/CommonMark/CommonMark.py
@@ -111,9 +111,7 @@ def dumpAST(obj, ind=0):
             print(
                 "\t\t" + indChar + "[marker_offset] = " +
                 str(obj.list_data.get('marker_offset')))
-    if obj.first_child:
+    if obj.is_container():
         print("\t" + indChar + "Children:")
-        node = obj.first_child
-        while node is not None:
+        for node in obj.children():
             dumpAST(node, ind + 2)
-            node = node.nxt

--- a/CommonMark/CommonMark.py
+++ b/CommonMark/CommonMark.py
@@ -67,7 +67,7 @@ def ASTtoJSON(block):
     return json.dumps(prepare(block), default=lambda o: o.__dict__)
 
 
-def dumpAST(obj, ind=0, topnode=False):
+def dumpAST(obj, ind=0):
     """ Print out a block/entire AST."""
     indChar = ("\t" * ind) + "-> " if ind else ""
     print(indChar + "[" + obj.t + "]")
@@ -111,10 +111,9 @@ def dumpAST(obj, ind=0, topnode=False):
             print(
                 "\t\t" + indChar + "[marker_offset] = " +
                 str(obj.list_data.get('marker_offset')))
-    if obj.walker:
+    if obj.first_child:
         print("\t" + indChar + "Children:")
-        walker = obj.walker()
-        nxt = walker.nxt()
-        while nxt is not None and topnode is False:
-            dumpAST(nxt['node'], ind + 2, topnode=True)
-            nxt = walker.nxt()
+        node = obj.first_child
+        while node is not None:
+            dumpAST(node, ind + 2)
+            node = node.nxt

--- a/CommonMark/CommonMark.py
+++ b/CommonMark/CommonMark.py
@@ -50,14 +50,12 @@ def prepare(block):
     if block.is_open is not None:
         block.__dict__['open'] = block.is_open
         del(block.is_open)
+
     # trim empty elements...
-    for attr in dir(block):
-        if not callable(attr) and not attr.startswith("__") and \
-           attr not in ['pretty', 'is_container',
-                        'append_child', 'prepend_child', 'unlink',
-                        'insert_after', 'insert_before', 'walker']:
-            if block.__dict__[attr] in ["", [], None, {}]:
-                del(block.__dict__[attr])
+    for attr, value in block.__dict__.items():
+        if not attr.startswith("__"):
+            if value in ["", [], None, {}]:
+                del block.__dict__[attr]
     return block
 
 

--- a/CommonMark/CommonMark.py
+++ b/CommonMark/CommonMark.py
@@ -49,10 +49,10 @@ def prepare(block):
         block.__dict__[r] = None
     if block.is_open is not None:
         block.__dict__['open'] = block.is_open
-        del(block.is_open)
+        del block.is_open
 
     # trim empty elements...
-    for attr, value in block.__dict__.items():
+    for attr, value in list(block.__dict__.items()):
         if not attr.startswith("__"):
             if value in ["", [], None, {}]:
                 del block.__dict__[attr]

--- a/CommonMark/node.py
+++ b/CommonMark/node.py
@@ -90,6 +90,12 @@ class Node(object):
     def is_container(self):
         return is_container(self)
 
+    def children(self):
+        node = self.first_child
+        while node is not None:
+            yield node
+            node = node.nxt
+
     def append_child(self, child):
         child.unlink()
         child.parent = self


### PR DESCRIPTION
The previous code would always print out only two levels of nesting, when in fact the AST is much more tree-like. This fixes the iteration, and adds a convenience method to make this kind of thing easier elsewhere.

Is this trying to match the api of another implementation, or is it ok to expose extra functions?