### PR TITLE
Set softbreak by parameter

### DIFF
--- a/CommonMark/html.py
+++ b/CommonMark/html.py
@@ -31,11 +31,11 @@ def potentially_unsafe(url):
 
 class HtmlRenderer(object):
 
-    def __init__(self, options={}):
+    def __init__(self, options={}, softbreak='\n'):
         # by default, soft breaks are rendered as newlines in HTML.
         # set to "<br />" to make them hard breaks
         # set to " " if you want to ignore line wrapping in source
-        self.softbreak = '\n'
+        self.softbreak = softbreak
         self.options = options
 
     def out(self, s):


### PR DESCRIPTION
Is there a reason soft-breaks are not set by parameter?