### PR TITLE
Fix TypeError: unsupported operand type(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed a bug where a TypeError could occur, reported by @civalin
+
 ## 0.6.4 (2016-05-09)
 - The CommonMark spec has been updated to 0.25.
 - The HtmlRenderer has been refactored based on upstream changes in commonmark.js.

--- a/CommonMark/node.py
+++ b/CommonMark/node.py
@@ -79,7 +79,7 @@ class Node(object):
         self.sourcepos = sourcepos
         self.last_line_blank = False
         self.is_open = True
-        self.string_content = None
+        self.string_content = ''
         self.literal = None
         self.list_data = {}
         self.info = None

--- a/CommonMark/tests/unit_tests.py
+++ b/CommonMark/tests/unit_tests.py
@@ -22,6 +22,13 @@ class TestCommonmark(unittest.TestCase):
         CommonMark.commonmark('# unicode: \u2020')
         CommonMark.commonmark('```\n# unicode: \u2020\n```')
 
+    def test_null_string_bug(self):
+        s = CommonMark.commonmark('>     sometext\n>\n\n')
+        self.assertEqual(
+            s,
+            '<blockquote>\n<pre><code>sometext\n</code></pre>'
+            '\n</blockquote>\n')
+
 
 class TestHtmlRenderer(unittest.TestCase):
     def test_init(self):


### PR DESCRIPTION
This fixes the bug reported by civalin and adds a regression test.
JavaScript is more flexible about inferring types than Python, which is
what caused this problem.

Closes #66