### PR TITLE
Fix spurious path in cmark script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ script:
  - python setup.py flake8
  - python -m unittest CommonMark.tests.unit_tests
  - python setup.py test
- - cmark.py CommonMark/tests/test.md
- - cmark.py CommonMark/tests/test.md -a
- - cmark.py CommonMark/tests/test.md -aj
+ - cmark CommonMark/tests/test.md
+ - cmark CommonMark/tests/test.md -a
+ - cmark CommonMark/tests/test.md -aj

--- a/CommonMark/cmark.py
+++ b/CommonMark/cmark.py
@@ -6,7 +6,7 @@ import CommonMark
 parser = argparse.ArgumentParser(
     description="Process Markdown according to the CommonMark specification.")
 if sys.version_info < (3, 0):
-    reload(sys)
+    reload(sys)  # noqa
     sys.setdefaultencoding('utf-8')
 parser.add_argument(
     'infile',

--- a/CommonMark/tests/test.md
+++ b/CommonMark/tests/test.md
@@ -27,11 +27,11 @@ Usage
 
     ----- or -----
 
-	rolands@kamaji:~$ cmark.py README.md -o README.html
-	rolands@kamaji:~$ cmark.py README.md -o README.json -aj # output AST as JSON
-	rolands@kamaji:~$ cmark.py README.md -a # pretty print generated AST structure
-	rolands@kamaji:~$ cmark.py -h
-	usage: cmark.py [-h] [-o [O]] [-a] [-aj] [infile]
+	rolands@kamaji:~$ cmark README.md -o README.html
+	rolands@kamaji:~$ cmark README.md -o README.json -aj # output AST as JSON
+	rolands@kamaji:~$ cmark README.md -a # pretty print generated AST structure
+	rolands@kamaji:~$ cmark -h
+	usage: cmark [-h] [-o [O]] [-a] [-aj] [infile]
 
 	Process Markdown according to the CommonMark specification.
 

--- a/README.rst
+++ b/README.rst
@@ -48,11 +48,11 @@ Usage
 
     ----- or -----
 
-    rolands@kamaji:~$ cmark.py README.md -o README.html
-    rolands@kamaji:~$ cmark.py README.md -o README.json -aj # output AST as JSON
-    rolands@kamaji:~$ cmark.py README.md -a # pretty print generated AST structure
-    rolands@kamaji:~$ cmark.py -h
-    usage: cmark.py [-h] [-o [O]] [-a] [-aj] [infile]
+    rolands@kamaji:~$ cmark README.md -o README.html
+    rolands@kamaji:~$ cmark README.md -o README.json -aj # output AST as JSON
+    rolands@kamaji:~$ cmark README.md -a # pretty print generated AST structure
+    rolands@kamaji:~$ cmark -h
+    usage: cmark [-h] [-o [O]] [-a] [-aj] [infile]
 
     Process Markdown according to the CommonMark specification.
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ class Test(Command):
 setup(
     name="CommonMark",
     packages=find_packages(exclude=['tests']),
-    scripts=['bin/cmark.py'],
     version="0.6.4",
     license="BSD License",
     description="Python parser for the CommonMark Markdown spec",
@@ -32,6 +31,11 @@ setup(
     maintainer_email="nikolas@gnu.org",
     url="https://github.com/rtfd/CommonMark-py",
     keywords=["markup", "markdown", "commonmark"],
+    entry_points={
+        'console_scripts': [
+            'cmark = CommonMark.cmark:cmark',
+        ]
+    },
     cmdclass={'test': Test},
     install_requires=[
         'future',


### PR DESCRIPTION
This changes `cmark.py` to `cmark` and moves the script from
the bin folder to the main package folder. So now it will be checked
by flake8.

I fixed the issue by following the piprot tool's example: declaring
the executable script via setup.py's entry_points instead of scripts.

flake8 also does it this way: https://github.com/PyCQA/flake8/blob/master/setup.py#L58

Closes #59