### PR TITLE
Limit flake8 to py2.6-compatible version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.5"
 install:
  - python setup.py install
- - pip install flake8 hypothesis hypothesislegacysupport
+ - pip install flake8==2.6.2 hypothesis hypothesislegacysupport
 script:
  - python setup.py flake8
  - python -m unittest CommonMark.tests.unit_tests

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'future',
     ],
     tests_require=[
-        'flake8',
+        'flake8==2.6.2',
         'hypothesis',
         # For python 2.6
         'hypothesislegacysupport',


### PR DESCRIPTION
Addressing this issue:
https://travis-ci.org/rtfd/CommonMark-py/jobs/151256231