### PR TITLE
Added sourcepos to link nodes.

### DIFF
--- a/CommonMark/inlines.py
+++ b/CommonMark/inlines.py
@@ -594,9 +594,13 @@ class InlineParser(object):
 
         savepos = self.pos
 
+        link_start = 0
+        link_end = 0
+
         # Inline link?
         if self.peek() == '(':
             self.pos += 1
+            link_start = self.pos + 1
             self.spnl()
             dest = self.parseLinkDestination()
             if dest is not None and self.spnl():
@@ -608,6 +612,8 @@ class InlineParser(object):
                     matched = True
             else:
                 self.pos = savepos
+
+            link_end = self.pos - 1
 
         if not matched:
             # Next, see if there's a link label
@@ -634,7 +640,9 @@ class InlineParser(object):
                     matched = True
 
         if matched:
-            node = Node('image' if is_image else 'link', None)
+            pos = list(block.sourcepos)
+            pos[1] = [link_start, link_end]
+            node = Node('image' if is_image else 'link', pos)
 
             node.destination = dest
             node.title = title or ''


### PR DESCRIPTION
Ref issue: #91
This is somewhat of a naive patch that adds sourcepos information to 'link' nodes. To construct the sourcepos information:
 - the row information is copied from the block passed to parseCloseBracket.
 - link_start and link_end are used to keep track of the opening and close parentheses which are used to form the column information.

There's probably a whole load of things that I've not thought of, so happy to take on any comments and extend the PR.