### PR TITLE
Add a reStructuredText renderer

### DIFF
--- a/CommonMark/__init__.py
+++ b/CommonMark/__init__.py
@@ -5,3 +5,4 @@ from CommonMark.main import commonmark
 from CommonMark.dump import dumpAST, dumpJSON
 from CommonMark.blocks import Parser
 from CommonMark.render.html import HtmlRenderer
+from CommonMark.render.rst import ReStructuredTextRenderer

--- a/CommonMark/main.py
+++ b/CommonMark/main.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, unicode_literals
 from CommonMark.blocks import Parser
 from CommonMark.dump import dumpAST, dumpJSON
 from CommonMark.render.html import HtmlRenderer
+from CommonMark.render.rst import ReStructuredTextRenderer
 
 
 def commonmark(text, format="html"):
@@ -26,7 +27,7 @@ def commonmark(text, format="html"):
     """
     parser = Parser()
     ast = parser.parse(text)
-    if format not in ["html", "json", "ast"]:
+    if format not in ["html", "json", "ast", "rst"]:
         raise ValueError("format must be 'html', 'json' or 'ast'")
     if format == "html":
         renderer = HtmlRenderer()
@@ -35,3 +36,6 @@ def commonmark(text, format="html"):
         return dumpJSON(ast)
     if format == "ast":
         return dumpAST(ast)
+    if format == "rst":
+        renderer = ReStructuredTextRenderer()
+        return renderer.render(ast)

--- a/CommonMark/render/rst.py
+++ b/CommonMark/render/rst.py
@@ -11,9 +11,9 @@ class ReStructuredTextRenderer(Renderer):
 
     def lit(self, s):
         if s == '\n':
-            indent = u''  # Avoid whitespace if we're just adding a newline
+            indent = ''  # Avoid whitespace if we're just adding a newline
         elif self.last_out != '\n':
-            indent = u''  # Don't indent if we're in the middle of a line
+            indent = ''  # Don't indent if we're in the middle of a line
         else:
             indent = self.indent_char * self.indent_length
 

--- a/CommonMark/render/rst.py
+++ b/CommonMark/render/rst.py
@@ -1,0 +1,143 @@
+from __future__ import unicode_literals
+
+
+from CommonMark.render.renderer import Renderer
+
+
+class ReStructuredTextRenderer(Renderer):
+    def __init__(self, indent_char=' '):
+        self.indent_char = indent_char
+        self.indent_length = 0
+
+    def lit(self, s):
+        if s == '\n':
+            indent = u''  # Avoid whitespace if we're just adding a newline
+        elif self.last_out != '\n':
+            indent = u''  # Don't indent if we're in the middle of a line
+        else:
+            indent = self.indent_char * self.indent_length
+
+        return super(ReStructuredTextRenderer, self).lit(indent + s)
+
+    def cr(self):
+        self.lit('\n')
+
+    def indent_lines(self, literal, indent_length=4):
+        indent = self.indent_char * indent_length
+        new_lines = []
+
+        for line in literal.splitlines():
+            new_lines.append(indent + line)
+
+        return '\n'.join(new_lines)
+
+    # Nodes
+
+    def document(self, node, entering):
+        pass
+
+    def softbreak(self, node, entering):
+        self.cr()
+
+    def linebreak(self, node, entering):
+        self.cr()
+        self.cr()
+
+    def text(self, node, entering):
+        self.out(node.literal)
+
+    def emph(self, node, entering):
+        self.out('*')
+
+    def strong(self, node, entering):
+        self.out('**')
+
+    def paragraph(self, node, entering):
+        if node.parent.t == 'item':
+            pass
+        else:
+            self.cr()
+
+    def link(self, node, entering):
+        if entering:
+            self.out('`')
+        else:
+            self.out(' <%s>`_' % node.destination)
+
+    def image(self, node, entering):
+        directive = '.. image:: ' + node.destination
+
+        if entering:
+            self.out(directive)
+            self.cr()
+            self.indent_length += 4
+            self.out(':alt: ')
+        else:
+            self.indent_length -= 4
+
+    def code(self, node, entering):
+        self.out('``')
+        self.out(node.literal)
+        self.out('``')
+
+    def code_block(self, node, entering):
+        directive = '.. code::'
+        language_name = None
+
+        info_words = node.info.split() if node.info else []
+        if len(info_words) > 0 and len(info_words[0]) > 0:
+            language_name = info_words[0]
+
+        if language_name:
+            directive += ' ' + language_name
+
+        self.cr()
+        self.out(directive)
+        self.cr()
+        self.cr()
+        self.out(self.indent_lines(node.literal))
+        self.cr()
+
+    def list(self, node, entering):
+        if entering:
+            self.cr()
+
+    def item(self, node, entering):
+        tagname = '*' if node.list_data['type'] == 'bullet' else '#.'
+
+        if entering:
+            self.out(tagname + ' ')
+        else:
+            self.cr()
+
+    def block_quote(self, node, entering):
+        if entering:
+            self.indent_length += 4
+        else:
+            self.indent_length -= 4
+
+    def heading(self, node, entering):
+        heading_chars = [
+            '#',
+            '*',
+            '=',
+            '-',
+            '^',
+            '"'
+        ]
+
+        try:
+            heading_char = heading_chars[node.level-1]
+        except IndexError:
+            # Default to the last level if we're in too deep
+            heading_char = heading_chars[-1]
+
+        heading_length = len(node.first_child.literal)
+        banner = heading_char * heading_length
+
+        if entering:
+            self.cr()
+        else:
+            self.cr()
+            self.out(banner)
+            self.cr()

--- a/CommonMark/render/rst.py
+++ b/CommonMark/render/rst.py
@@ -5,6 +5,22 @@ from CommonMark.render.renderer import Renderer
 
 
 class ReStructuredTextRenderer(Renderer):
+    """
+    Render reStructuredText from Markdown
+
+    Example:
+
+    .. code:: python
+
+        import CommonMark
+
+        parser = CommonMark.Parser()
+        ast = parser.parse('Hello `inline code` example')
+
+        renderer = CommonMark.ReStructuredTextRenderer()
+        rst = renderer.render(ast)
+        print(rst)  # Hello ``inline code`` example
+    """
     def __init__(self, indent_char=' '):
         self.indent_char = indent_char
         self.indent_length = 0

--- a/CommonMark/tests/rst_tests.py
+++ b/CommonMark/tests/rst_tests.py
@@ -1,0 +1,171 @@
+import unittest
+
+import CommonMark
+
+
+class TestCommonmark(unittest.TestCase):
+    def setUp(self):
+        self.parser = CommonMark.Parser()
+        self.renderer = CommonMark.ReStructuredTextRenderer()
+
+    def render_rst(self, test_str):
+        ast = self.parser.parse(test_str)
+        rst = self.renderer.render(ast)
+
+        return rst
+
+    def assertEqualRender(self, src_markdown, expected_rst):
+        rendered_rst = self.render_rst(src_markdown)
+        self.assertEqual(rendered_rst, expected_rst)
+
+    def test_strong(self):
+        src_markdown = 'Hello **Strong**'
+        expected_rst = '\nHello **Strong**\n'
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_emphasis(self):
+        src_markdown = 'Hello *Emphasis*'
+        expected_rst = '\nHello *Emphasis*\n'
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_paragraph(self):
+        src_markdown = 'Hello paragraph'
+        expected_rst = '\nHello paragraph\n'
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_link(self):
+        src_markdown = '[Link](http://example.com)'
+        expected_rst = '\n`Link <http://example.com>`_\n'
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_image(self):
+        src_markdown = '![Image](http://placekitten.com/100/100)'
+        expected_rst = """
+.. image:: http://placekitten.com/100/100
+    :alt: Image
+"""
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_code(self):
+        src_markdown = 'Test `inline code` with backticks'
+        expected_rst = '\nTest ``inline code`` with backticks\n'
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_code_block(self):
+        src_markdown = """
+```python
+# code block
+print '3 backticks or'
+print 'indent 4 spaces'
+```
+"""
+        expected_rst = """
+.. code:: python
+
+    # code block
+    print '3 backticks or'
+    print 'indent 4 spaces'
+"""
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_unordered_list(self):
+        src_markdown = """
+This is a list:
+* List item
+* List item
+* List item
+"""
+        expected_rst = """
+This is a list:
+
+* List item
+* List item
+* List item
+"""
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_ordered_list(self):
+        src_markdown = """
+This is a ordered list:
+1. One
+2. Two
+3. Three
+"""
+        expected_rst = """
+This is a ordered list:
+
+#. One
+#. Two
+#. Three
+"""
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_block_quote(self):
+        src_markdown = """
+Before the blockquote:
+
+> The blockquote
+
+After the blockquote
+"""
+        expected_rst = """
+Before the blockquote:
+
+    The blockquote
+
+After the blockquote
+"""
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_heading(self):
+        src_markdown = '''
+# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+#### Heading 4
+
+##### Heading 5
+
+###### Heading 6
+'''
+        expected_rst = '''
+Heading 1
+#########
+
+Heading 2
+*********
+
+Heading 3
+=========
+
+Heading 4
+---------
+
+Heading 5
+^^^^^^^^^
+
+Heading 6
+"""""""""
+'''
+        self.assertEqualRender(src_markdown, expected_rst)
+
+    def test_multiple_paragraphs(self):
+        src_markdown = '''
+Start of first paragraph that
+continues on a new line
+
+This is the second paragraph
+'''
+        expected_rst = '''
+Start of first paragraph that
+continues on a new line
+
+This is the second paragraph
+'''
+        self.assertEqualRender(src_markdown, expected_rst)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,5 +5,6 @@ API
    :maxdepth: 2
 
    html
+   rst
    parser
    node

--- a/docs/rst.rst
+++ b/docs/rst.rst
@@ -1,0 +1,7 @@
+reStructuredText
+================
+
+.. currentmodule:: CommonMark.render.rst
+
+.. autoclass:: ReStructuredTextRenderer
+   :members:


### PR DESCRIPTION
I work a lot with Sphinx and often need to convert things from Markdown to reStructuredText. This PR introduces a new renderer for reStructuredText.

Why not use rtfd/recommonmark? That Sphinx extension allows entire documents to be written in Markdown. I've written Sphinx extensions that only need to convert a single paragraph at a time from JSON files.

Previously I've relied on using `pandoc` to convert Markdown to reStructuredText. That's a pain because you need to have it installed locally.

If you don't find this useful for the core library, I can always make a standalone library.