### PR TITLE
update commonmark spec to 0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.4
+- The CommonMark spec has been updated to 0.28.
+
 ## 0.7.3 (2017-01-05)
 - The CommonMark spec has been updated to 0.27.
 

--- a/CommonMark/blocks.py
+++ b/CommonMark/blocks.py
@@ -94,8 +94,8 @@ def parse_list_marker(parser, container):
         'padding': None,
         'marker_offset': parser.indent,
     }
-    m = re.match(reBulletListMarker, rest)
-    m2 = re.match(reOrderedListMarker, rest)
+    m = re.search(reBulletListMarker, rest)
+    m2 = re.search(reOrderedListMarker, rest)
     if m:
         data['type'] = 'bullet'
         data['bullet_char'] = m.group()[0]
@@ -320,7 +320,7 @@ class CodeBlock(Block):
             match = indent <= 3 and \
                 len(ln) >= parser.next_nonspace + 1 and \
                 ln[parser.next_nonspace] == container.fence_char and \
-                re.match(reClosingCodeFence, ln[parser.next_nonspace:])
+                re.search(reClosingCodeFence, ln[parser.next_nonspace:])
             if match and len(match.group()) >= container.fence_length:
                 # closing fence - we're at end of line, so we can return
                 parser.finalize(container, parser.line_number)
@@ -448,8 +448,8 @@ class BlockStarts(object):
     @staticmethod
     def atx_heading(parser, container=None):
         if not parser.indented:
-            m = re.match(reATXHeadingMarker,
-                         parser.current_line[parser.next_nonspace:])
+            m = re.search(reATXHeadingMarker,
+                          parser.current_line[parser.next_nonspace:])
             if m:
                 parser.advance_next_nonspace()
                 parser.advance_offset(len(m.group()), False)
@@ -459,8 +459,10 @@ class BlockStarts(object):
                 container.level = len(m.group().strip())
                 # remove trailing ###s:
                 container.string_content = re.sub(
-                    r' +#+ *$', '', re.sub(
-                        r'^ *#+ *$', '', parser.current_line[parser.offset:]))
+                    r'[ \t]+#+[ \t]*$', '', re.sub(
+                        r'^[ \t]*#+[ \t]*$',
+                        '',
+                        parser.current_line[parser.offset:]))
                 parser.advance_offset(
                     len(parser.current_line) - parser.offset, False)
                 return 2
@@ -470,7 +472,7 @@ class BlockStarts(object):
     @staticmethod
     def fenced_code_block(parser, container=None):
         if not parser.indented:
-            m = re.match(
+            m = re.search(
                 reCodeFence,
                 parser.current_line[parser.next_nonspace:])
             if m:
@@ -508,7 +510,7 @@ class BlockStarts(object):
     @staticmethod
     def setext_heading(parser, container=None):
         if not parser.indented and container.t == 'paragraph':
-            m = re.match(
+            m = re.search(
                 reSetextHeadingLine,
                 parser.current_line[parser.next_nonspace:])
             if m:

--- a/CommonMark/inlines.py
+++ b/CommonMark/inlines.py
@@ -22,8 +22,32 @@ else:
 ESCAPED_CHAR = '\\\\' + common.ESCAPABLE
 
 rePunctuation = re.compile(
-    r'^[\u2000-\u206F\u2E00-\u2E7F\\' + "'" + '!"#\$%&\(\)'
-    r'\*\+,\-\.\/:;<=>\?@\[\]\^_`\{\|\}~]')
+    r'[!"#$%&\'()*+,\-./:;<=>?@\[\]^_`{|}~\xA1\xA7\xAB\xB6\xB7\xBB'
+    r'\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3'
+    r'\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F'
+    r'\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E'
+    r'\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12'
+    r'\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB'
+    r'\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736'
+    r'\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-'
+    r'\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F'
+    r'\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E'
+    r'\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5'
+    r'\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC'
+    r'\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E42\u3001-\u3003\u3008-\u3011'
+    r'\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673'
+    r'\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E'
+    r'\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0'
+    r'\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63'
+    r'\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B'
+    r'\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-'
+    r'\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58'
+    r'\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D'
+    r'\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD'
+    r'\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDCC6\uDDC1-\uDDD7'
+    r'\uDE41-\uDE43\uDF3C-\uDF3E]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F'
+    r'\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]'
+)
 
 reLinkTitle = re.compile(
     '^(?:"(' + ESCAPED_CHAR + '|[^"\\x00])*"' +
@@ -184,7 +208,7 @@ class InlineParser(object):
             self.pos += 1
             node = Node('linebreak', None)
             block.append_child(node)
-        elif subjchar and re.match(reEscapable, subjchar):
+        elif subjchar and re.search(reEscapable, subjchar):
             block.append_child(text(subjchar))
             self.pos += 1
         else:
@@ -258,21 +282,22 @@ class InlineParser(object):
             c_after = '\n'
 
         # Python 2 doesn't recognize '\xa0' as whitespace
-        after_is_whitespace = re.match(reUnicodeWhitespaceChar, c_after) or \
+        after_is_whitespace = re.search(reUnicodeWhitespaceChar, c_after) or \
             c_after == '\xa0'
-        after_is_punctuation = re.match(rePunctuation, c_after)
-        before_is_whitespace = re.match(reUnicodeWhitespaceChar, c_before) or \
+        after_is_punctuation = re.search(rePunctuation, c_after)
+        before_is_whitespace = re.search(
+            reUnicodeWhitespaceChar, c_before) or \
             c_before == '\xa0'
-        before_is_punctuation = re.match(rePunctuation, c_before)
+        before_is_punctuation = re.search(rePunctuation, c_before)
 
         left_flanking = not after_is_whitespace and \
-            not (after_is_punctuation and
-                 not before_is_whitespace and
-                 not before_is_punctuation)
+            (not after_is_punctuation or
+             before_is_whitespace or
+             before_is_punctuation)
         right_flanking = not before_is_whitespace and \
-            not (before_is_punctuation and
-                 not after_is_whitespace and
-                 not after_is_punctuation)
+            (not before_is_punctuation or
+             after_is_whitespace or
+             after_is_punctuation)
         if c == '_':
             can_open = left_flanking and \
                 (not right_flanking or before_is_punctuation)
@@ -385,16 +410,9 @@ class InlineParser(object):
                     else:
                         # Calculate actual number of delimiters used from
                         # closer
-                        if closer['numdelims'] < 3 or opener['numdelims'] < 3:
-                            if closer['numdelims'] <= opener['numdelims']:
-                                use_delims = closer['numdelims']
-                            else:
-                                use_delims = opener['numdelims']
-                        else:
-                            if closer['numdelims'] % 2 == 0:
-                                use_delims = 2
-                            else:
-                                use_delims = 1
+                        use_delims = 2 if (
+                            closer['numdelims'] >= 2 and
+                            opener['numdelims'] >= 2) else 1
 
                         opener_inl = opener.get('node')
                         closer_inl = closer.get('node')
@@ -502,7 +520,7 @@ class InlineParser(object):
                     else:
                         self.pos += 1
                         openparens -= 1
-                elif re.match(reWhitespaceChar, c):
+                elif re.search(reWhitespaceChar, c):
                     break
                 else:
                     self.pos += 1
@@ -518,8 +536,10 @@ class InlineParser(object):
         Attempt to parse a link label, returning number of
         characters parsed.
         """
+        # Note: our regex will allow something of form [..\];
+        # we disallow it here rather than using lookahead in the regex:
         m = self.match(reLinkLabel)
-        if m is None or len(m) > 1001 or re.match(r'\[\s+\]', m):
+        if m is None or len(m) > 1001 or re.search(r'([^\\]\\\]$|\[\n\]$)', m):
             return 0
         else:
             return len(m)
@@ -601,7 +621,7 @@ class InlineParser(object):
             dest = self.parseLinkDestination()
             if dest is not None and self.spnl():
                 # make sure there's a space before the title
-                if re.match(reWhitespaceChar, self.subject[self.pos-1]):
+                if re.search(reWhitespaceChar, self.subject[self.pos-1]):
                     title = self.parseLinkTitle()
                 if self.spnl() and self.peek() == ')':
                     self.pos += 1

--- a/CommonMark/node.py
+++ b/CommonMark/node.py
@@ -10,7 +10,7 @@ reContainer = re.compile(
 
 
 def is_container(node):
-    return (re.match(reContainer, node.t) is not None)
+    return (re.search(reContainer, node.t) is not None)
 
 
 class NodeWalker(object):

--- a/CommonMark/render/html.py
+++ b/CommonMark/render/html.py
@@ -14,8 +14,8 @@ reSafeDataProtocol = re.compile(
 
 
 def potentially_unsafe(url):
-    return re.match(reUnsafeProtocol, url) and \
-        (not re.match(reSafeDataProtocol, url))
+    return re.search(reUnsafeProtocol, url) and \
+        (not re.search(reSafeDataProtocol, url))
 
 
 class HtmlRenderer(Renderer):

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ tracing.
 
 ::
 
-    $ python run_spec_tests.py -h
+    $ ./venv/bin/python CommonMark/tests/run_spec_tests.py -h
     usage: run_spec_tests.py [-h] [-t T] [-p] [-f] [-i] [-d] [-np] [-s]
 
     script to run the CommonMark specification tests against the CommonMark.py

--- a/spec.txt
+++ b/spec.txt
@@ -1,8 +1,8 @@
 ---
 title: CommonMark Spec
 author: John MacFarlane
-version: 0.27
-date: '2016-11-18'
+version: 0.28
+date: '2017-08-01'
 license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
 ...
 
@@ -11,10 +11,12 @@ license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
 ## What is Markdown?
 
 Markdown is a plain text format for writing structured documents,
-based on conventions used for indicating formatting in email and
-usenet posts.  It was developed in 2004 by John Gruber, who wrote
-the first Markdown-to-HTML converter in Perl, and it soon became
-ubiquitous.  In the next decade, dozens of implementations were
+based on conventions for indicating formatting in email
+and usenet posts.  It was developed by John Gruber (with
+help from Aaron Swartz) and released in 2004 in the form of a
+[syntax description](http://daringfireball.net/projects/markdown/syntax)
+and a Perl script (`Markdown.pl`) for converting Markdown to
+HTML.  In the next decade, dozens of implementations were
 developed in many languages.  Some extended the original
 Markdown syntax with conventions for footnotes, tables, and
 other document elements.  Some allowed Markdown documents to be
@@ -312,7 +314,7 @@ form feed (`U+000C`), or carriage return (`U+000D`).
 characters].
 
 A [Unicode whitespace character](@) is
-any code point in the Unicode `Zs` class, or a tab (`U+0009`),
+any code point in the Unicode `Zs` general category, or a tab (`U+0009`),
 carriage return (`U+000D`), newline (`U+000A`), or form feed
 (`U+000C`).
 
@@ -331,7 +333,7 @@ is `!`, `"`, `#`, `$`, `%`, `&`, `'`, `(`, `)`,
 
 A [punctuation character](@) is an [ASCII
 punctuation character] or anything in
-the Unicode classes `Pc`, `Pd`, `Pe`, `Pf`, `Pi`, `Po`, or `Ps`.
+the general Unicode categories  `Pc`, `Pd`, `Pe`, `Pf`, `Pi`, `Po`, or `Ps`.
 
 ## Tabs
 
@@ -402,8 +404,8 @@ as indentation with four spaces would:
 Normally the `>` that begins a block quote may be followed
 optionally by a space, which is not considered part of the
 content.  In the following case `>` is followed by a tab,
-which is treated as if it were expanded into spaces.
-Since one of theses spaces is considered part of the
+which is treated as if it were expanded into three spaces.
+Since one of these spaces is considered part of the
 delimiter, `foo` is considered to be indented six spaces
 inside the block quote context, so we get an indented
 code block starting with two spaces.
@@ -481,7 +483,7 @@ We can think of a document as a sequence of
 quotations, lists, headings, rules, and code blocks.  Some blocks (like
 block quotes and list items) contain other blocks; others (like
 headings and paragraphs) contain [inline](@) content---text,
-links, emphasized text, images, code, and so on.
+links, emphasized text, images, code spans, and so on.
 
 ## Precedence
 
@@ -1643,6 +1645,15 @@ With tildes:
 </code></pre>
 ````````````````````````````````
 
+Fewer than three backticks is not enough:
+
+```````````````````````````````` example
+``
+foo
+``
+.
+<p><code>foo</code></p>
+````````````````````````````````
 
 The closing code fence must use the same character as the opening
 fence:
@@ -2030,6 +2041,37 @@ or [closing tag] (with any [tag name] other than `script`,
 `style`, or `pre`) followed only by [whitespace]
 or the end of the line.\
 **End condition:** line is followed by a [blank line].
+
+HTML blocks continue until they are closed by their appropriate
+[end condition], or the last line of the document or other [container block].
+This means any HTML **within an HTML block** that might otherwise be recognised
+as a start condition will be ignored by the parser and passed through as-is,
+without changing the parser's state.
+
+For instance, `<pre>` within a HTML block started by `<table>` will not affect
+the parser state; as the HTML block was started in by start condition 6, it
+will end at any blank line. This can be surprising:
+
+```````````````````````````````` example
+<table><tr><td>
+<pre>
+**Hello**,
+
+_world_.
+</pre>
+</td></tr></table>
+.
+<table><tr><td>
+<pre>
+**Hello**,
+<p><em>world</em>.
+</pre></p>
+</td></tr></table>
+````````````````````````````````
+
+In this case, the HTML block is terminated by the newline — the `**hello**`
+text remains verbatim — and regular parsing resumes, with a paragraph,
+emphasised `world` and inline and block HTML following.
 
 All types of [HTML blocks] except type 7 may interrupt
 a paragraph.  Blocks of type 7 may not interrupt a paragraph.
@@ -3637,11 +3679,15 @@ The following rules define [list items]:
     If the list item is ordered, then it is also assigned a start
     number, based on the ordered list marker.
 
-    Exceptions: When the first list item in a [list] interrupts
-    a paragraph---that is, when it starts on a line that would
-    otherwise count as [paragraph continuation text]---then (a)
-    the lines *Ls* must not begin with a blank line, and (b) if
-    the list item is ordered, the start number must be 1.
+    Exceptions:
+
+    1. When the first list item in a [list] interrupts
+       a paragraph---that is, when it starts on a line that would
+       otherwise count as [paragraph continuation text]---then (a)
+       the lines *Ls* must not begin with a blank line, and (b) if
+       the list item is ordered, the start number must be 1.
+    2. If any line is a [thematic break][thematic breaks] then
+       that line is not a list item.
 
 For example, let *Ls* be the lines
 
@@ -5796,6 +5842,15 @@ we just have literal backticks:
 <p>`foo</p>
 ````````````````````````````````
 
+The following case also illustrates the need for opening and
+closing backtick strings to be equal in length:
+
+```````````````````````````````` example
+`foo``bar``
+.
+<p>`foo<code>bar</code></p>
+````````````````````````````````
+
 
 ## Emphasis and strong emphasis
 
@@ -5845,19 +5900,20 @@ for efficient parsing strategies that do not backtrack.
 
 First, some definitions.  A [delimiter run](@) is either
 a sequence of one or more `*` characters that is not preceded or
-followed by a `*` character, or a sequence of one or more `_`
-characters that is not preceded or followed by a `_` character.
+followed by a non-backslash-escaped `*` character, or a sequence
+of one or more `_` characters that is not preceded or followed by
+a non-backslash-escaped `_` character.
 
 A [left-flanking delimiter run](@) is
 a [delimiter run] that is (a) not followed by [Unicode whitespace],
-and (b) either not followed by a [punctuation character], or
+and (b) not followed by a [punctuation character], or
 preceded by [Unicode whitespace] or a [punctuation character].
 For purposes of this definition, the beginning and the end of
 the line count as Unicode whitespace.
 
 A [right-flanking delimiter run](@) is
 a [delimiter run] that is (a) not preceded by [Unicode whitespace],
-and (b) either not preceded by a [punctuation character], or
+and (b) not preceded by a [punctuation character], or
 followed by [Unicode whitespace] or a [punctuation character].
 For purposes of this definition, the beginning and the end of
 the line count as Unicode whitespace.
@@ -5936,7 +5992,7 @@ The following rules define emphasis and strong emphasis:
 7.  A double `**` [can close strong emphasis](@)
     iff it is part of a [right-flanking delimiter run].
 
-8.  A double `__` [can close strong emphasis]
+8.  A double `__` [can close strong emphasis] iff
     it is part of a [right-flanking delimiter run]
     and either (a) not part of a [left-flanking delimiter run]
     or (b) part of a [left-flanking delimiter run]
@@ -5976,8 +6032,8 @@ the following principles resolve ambiguity:
     an interpretation `<strong>...</strong>` is always preferred to
     `<em><em>...</em></em>`.
 
-14. An interpretation `<strong><em>...</em></strong>` is always
-    preferred to `<em><strong>..</strong></em>`.
+14. An interpretation `<em><strong>...</strong></em>` is always
+    preferred to `<strong><em>...</em></strong>`.
 
 15. When two potential emphasis or strong emphasis spans overlap,
     so that the second begins before the first ends and ends after
@@ -7000,14 +7056,14 @@ Rule 14:
 ```````````````````````````````` example
 ***foo***
 .
-<p><strong><em>foo</em></strong></p>
+<p><em><strong>foo</strong></em></p>
 ````````````````````````````````
 
 
 ```````````````````````````````` example
 _____foo_____
 .
-<p><strong><strong><em>foo</em></strong></strong></p>
+<p><em><strong><strong>foo</strong></strong></em></p>
 ````````````````````````````````
 
 
@@ -7148,7 +7204,9 @@ A [link destination](@) consists of either
 - a nonempty sequence of characters that does not include
   ASCII space or control characters, and includes parentheses
   only if (a) they are backslash-escaped or (b) they are part of
-  a balanced pair of unescaped parentheses.
+  a balanced pair of unescaped parentheses.  (Implementations
+  may impose limits on parentheses nesting to avoid performance
+  issues, but at least three levels of nesting should be supported.)
 
 A [link title](@)  consists of either
 
@@ -7254,7 +7312,7 @@ Parentheses inside the link destination may be escaped:
 <p><a href="(foo)">link</a></p>
 ````````````````````````````````
 
-Any number parentheses are allowed without escaping, as long as they are
+Any number of parentheses are allowed without escaping, as long as they are
 balanced:
 
 ```````````````````````````````` example
@@ -7560,13 +7618,16 @@ that [matches] a [link reference definition] elsewhere in the document.
 A [link label](@)  begins with a left bracket (`[`) and ends
 with the first right bracket (`]`) that is not backslash-escaped.
 Between these brackets there must be at least one [non-whitespace character].
-Unescaped square bracket characters are not allowed in
-[link labels].  A link label can have at most 999
-characters inside the square brackets.
+Unescaped square bracket characters are not allowed inside the
+opening and closing square brackets of [link labels].  A link
+label can have at most 999 characters inside the square
+brackets.
 
 One label [matches](@)
 another just in case their normalized forms are equal.  To normalize a
-label, perform the *Unicode case fold* and collapse consecutive internal
+label, strip off the opening and closing brackets,
+perform the *Unicode case fold*, strip leading and trailing
+[whitespace] and collapse consecutive internal
 [whitespace] to a single space.  If there are multiple
 matching reference link definitions, the one that comes first in the
 document is used.  (It is desirable in such cases to emit a warning.)
@@ -8319,11 +8380,11 @@ The link labels are case-insensitive:
 ````````````````````````````````
 
 
-If you just want bracketed text, you can backslash-escape the
-opening `!` and `[`:
+If you just want a literal `!` followed by bracketed text, you can
+backslash-escape the opening `[`:
 
 ```````````````````````````````` example
-\!\[foo]
+!\[foo]
 
 [foo]: /url "title"
 .


### PR DESCRIPTION
I also changed a bunch of calls from `re.match()` to `re.search()`,
because `re.match()` only searches from the start of the string, which
isn't how the equivalent javascript code behaves.