### PR TITLE
Add normalize() method for AST nodes

### DIFF
--- a/CommonMark/node.py
+++ b/CommonMark/node.py
@@ -100,6 +100,18 @@ class Node(object):
         from pprint import pprint
         pprint(self.__dict__)
 
+    def normalize(self):
+        prev = None
+        for curr, _ in self.walker():
+            if prev is None:
+                prev = curr
+                continue
+            if prev.t == 'text' and curr.t == 'text':
+                prev.literal += curr.literal
+                curr.unlink()
+            else:
+                prev = curr
+
     def is_container(self):
         return is_container(self)
 

--- a/CommonMark/tests/unit_tests.py
+++ b/CommonMark/tests/unit_tests.py
@@ -48,6 +48,31 @@ class TestCommonmark(unittest.TestCase):
             '<blockquote>\n<pre><code>sometext\n</code></pre>'
             '\n</blockquote>\n')
 
+    def test_normalize_contracts_text_nodes(self):
+        md = '_a'
+        ast = Parser().parse(md)
+
+        def assert_text_literals(text_literals):
+            walker = ast.walker()
+            document, _ = walker.next()
+            self.assertEqual(document.t, 'document')
+            paragraph, _ = walker.next()
+            self.assertEqual(paragraph.t, 'paragraph')
+            for literal in text_literals:
+                text, _ = walker.next()
+                self.assertEqual(text.t, 'text')
+                self.assertEqual(text.literal, literal)
+            paragraph, _ = walker.next()
+            self.assertEqual(paragraph.t, 'paragraph')
+
+        assert_text_literals(['_', 'a'])
+        ast.normalize()
+        # assert text nodes are contracted
+        assert_text_literals(['_a'])
+        ast.normalize()
+        # assert normalize() doesn't alter a normalized ast
+        assert_text_literals(['_a'])
+
     def test_dumpAST_orderedlist(self):
         md = '1.'
         ast = Parser().parse(md)


### PR DESCRIPTION
The parser produces an AST, which may contain multiple
text nodes in a row, which is difficult to work with.

Example commonmark input:

_unfinished emphasis

For this input the parser produces 2 separate text nodes
for "_" and "unfinished emphasis".

The normalize() method on an AST node will walk through
the tree and concatenate these consecutive text nodes.