### PR TITLE
No warnings

### DIFF
--- a/commonmark/common.py
+++ b/commonmark/common.py
@@ -10,8 +10,8 @@ except ImportError:
 
 if sys.version_info >= (3, 0):
     if sys.version_info >= (3, 4):
-        import html.parser
-        HTMLunescape = html.parser.HTMLParser().unescape
+        import html
+        HTMLunescape = html.unescape
     else:
         from .entitytrans import _unescape
         HTMLunescape = _unescape

--- a/commonmark/common.py
+++ b/commonmark/common.py
@@ -68,30 +68,26 @@ def unescape_string(s):
 
 def normalize_uri(uri):
     try:
-        return quote(uri, safe=str('/@:+?=&()%#*,'))
-    except KeyError:
-        # Python 2 throws a KeyError sometimes
-        try:
-            return quote(uri.encode('utf-8'), safe=str('/@:+?=&()%#*,'))
-        except UnicodeDecodeError:
-            # Python 2 also throws a UnicodeDecodeError, complaining about
-            # the width of the "safe" string. Removing this parameter
-            # solves the issue, but yields overly aggressive quoting, but we
-            # can correct those errors manually.
-            s = quote(uri.encode('utf-8'))
-            s = re.sub(r'%40', '@', s)
-            s = re.sub(r'%3A', ':', s)
-            s = re.sub(r'%2B', '+', s)
-            s = re.sub(r'%3F', '?', s)
-            s = re.sub(r'%3D', '=', s)
-            s = re.sub(r'%26', '&', s)
-            s = re.sub(r'%28', '(', s)
-            s = re.sub(r'%29', ')', s)
-            s = re.sub(r'%25', '%', s)
-            s = re.sub(r'%23', '#', s)
-            s = re.sub(r'%2A', '*', s)
-            s = re.sub(r'%2C', ',', s)
-            return s
+        return quote(uri.encode('utf-8'), safe=str('/@:+?=&()%#*,'))
+    except UnicodeDecodeError:
+        # Python 2 also throws a UnicodeDecodeError, complaining about
+        # the width of the "safe" string. Removing this parameter
+        # solves the issue, but yields overly aggressive quoting, but we
+        # can correct those errors manually.
+        s = quote(uri.encode('utf-8'))
+        s = re.sub(r'%40', '@', s)
+        s = re.sub(r'%3A', ':', s)
+        s = re.sub(r'%2B', '+', s)
+        s = re.sub(r'%3F', '?', s)
+        s = re.sub(r'%3D', '=', s)
+        s = re.sub(r'%26', '&', s)
+        s = re.sub(r'%28', '(', s)
+        s = re.sub(r'%29', ')', s)
+        s = re.sub(r'%25', '%', s)
+        s = re.sub(r'%23', '#', s)
+        s = re.sub(r'%2A', '*', s)
+        s = re.sub(r'%2C', ',', s)
+        return s
 
 
 UNSAFE_MAP = {

--- a/commonmark/inlines.py
+++ b/commonmark/inlines.py
@@ -8,8 +8,8 @@ from commonmark.node import Node
 
 if sys.version_info >= (3, 0):
     if sys.version_info >= (3, 4):
-        import html.parser
-        HTMLunescape = html.parser.HTMLParser().unescape
+        import html
+        HTMLunescape = html.unescape
     else:
         from .entitytrans import _unescape
         HTMLunescape = _unescape

--- a/commonmark/tests/run_spec_tests.py
+++ b/commonmark/tests/run_spec_tests.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 from __future__ import division, print_function, unicode_literals
 import re
-import time
+import timeit
 import codecs
 import argparse
 import sys
@@ -124,7 +124,7 @@ def main():
 
     current_section = ""
 
-    startTime = time.clock()
+    startTime = timeit.default_timer()
 
     if args.i:
         print(
@@ -223,7 +223,7 @@ def main():
 
     print('\n' + str(passed) + ' tests passed, ' + str(failed) + ' failed')
 
-    endTime = time.clock()
+    endTime = timeit.default_timer()
     runTime = endTime - startTime
 
     if args.s:


### PR DESCRIPTION
This pull-request ensures CommonMark-py does not produce `DeprecationWarning` or `UnicodeWarning` anymore. 

Changes made:
- Use `html.unescape` instead of `html.parser.HTMLParser.unescape` (which is deprecated since Python 3.3) on Python 3.3+
- Use `timeit.default_counter()` instead of `time.clock()` (`time.clock()` is deprecated since Python 3.3+ but `timeit.default_counter()` always use the right method on both Python 2 and 3)
- Don't try to quote the raw string, always quote the utf8 encoded. This remove the `UnicodeWarning` on Python 2.7 while still working on other versions